### PR TITLE
feat: Add GitHub Actions workflow for deploying to gh-pages

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,0 +1,41 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main # Assuming 'main' is the default branch. If it's 'master', this should be changed.
+  workflow_dispatch: # Allows manual triggering
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18' # Or a current LTS version
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 8 # Specify pnpm version, adjust if needed
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build project
+        run: pnpm run build # This runs 'gulp build' as per package.json
+
+      - name: Deploy to gh-pages branch
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          # Optional: if the base URL is not root (e.g., username.github.io/repo_name/)
+          # publish_branch: gh-pages # Default is gh-pages
+          # cname: your.custom.domain.com # If you have a custom domain
+          # user_name: 'github-actions[bot]' # Default
+          # user_email: 'github-actions[bot]@users.noreply.github.com' # Default


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow (`.github/workflows/deploy-gh-pages.yml`).

The workflow automates the deployment of the static site to GitHub Pages. It triggers on pushes to the `main` branch and can also be manually dispatched.

The workflow performs the following steps:
1. Checks out the repository.
2. Sets up Node.js and pnpm.
3. Installs project dependencies using `pnpm install`.
4. Builds the project using `pnpm run build` (which executes `gulp build`).
5. Deploys the contents of the `dist/` directory to the `gh-pages` branch using the `peaceiris/actions-gh-pages` action.

After this workflow runs successfully, you will need to configure your GitHub Pages settings to use the `gh-pages` branch as the publishing source (from the `/root` directory). This will ensure that `dist/index.html` is served as the main page.